### PR TITLE
Refactor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Note that this plugin naturally has a dependency of
 The POST endpoint that is created is `/wp/v2/cwp_gf_send_mail`. Naturally, you will to be authenticated in order to
 make a POST request. With the body of the request you will need to provide the following data:
 
-| Key       | Type   | Description                                                                                                                     |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `attrs`   | Object | The `attrs` object which comes from the WordPress API for the Gutenberg Forms block                                             |
-| `fields`  | Array  | The fields and their respective values. This must follow the same format that the form would provide naturally from the plugin. |
-| `post_id` | Number | The Post ID that the form originated from.                                                                                      |
+| Key       | Type   | Description                                                                                                   |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `attrs`   | Object | The `attrs` object which comes from the WordPress API for the Gutenberg Forms block                           |
+| `fields`  | Object | The fields in a key, value pattern. The key should be the field ID (this is `field_id` from the WP REST API). |
+| `post_id` | Number | The Post ID that the form originated from.                                                                    |
 
 Below is a breakdown of each property that should be sent in the POST request:
 
@@ -43,41 +43,16 @@ attrs: {
 ```
 
 ```javascript
-fields: [
-  {
-    decoded_entry: {
-      admin_id: "name_079d49",
-      extra_meta: null,
-      field_id: "079d49",
-      is_required: "false",
-      type: "name",
-    },
-    field_data_id: "079d49",
-    field_id: "079d49__LS1uYW1lLTA3OWQ0OS1mYWxzZS1uYW1lLW5hbWVfMDc5ZDQ5",
-    field_type: "name",
-    field_value: "Joe Bloggs",
-    is_valid: true,
-  },
-  {
-    decoded_entry: {
-      is_required: "false",
-      type: "email",
-      admin_id: "email_0ef4dc",
-      extra_meta: null,
-      field_id: "0ef4dc",
-    },
-    field_data_id: "0ef4dc",
-    field_id: "0ef4dc__LS1lbWFpbC0wZWY0ZGMtZmFsc2UtZW1haWwtZW1haWxfMGVmNGRj",
-    field_type: "email",
-    field_value: "joebloggs@yahoo.com",
-    is_valid: true,
-  },
+fields: {
+  "079d49__LS1uYW1lLTA3OWQ0OS1mYWxzZS1uYW1lLW5hbWVfMDc5ZDQ5": "Joe Bloggs",
+  "0ef4dc__LS1lbWFpbC0wZWY0ZGMtZmFsc2UtZW1haWwtZW1haWxfMGVmNGRj": "joebloggs@yahoo.com",
+  "adf2ea__LS1tZXNzYWdlLWFkZjJlYS1mYWxzZS1tZXNzYWdlLW1lc3NhZ2VfYWRmMmVh": "I'm a message"
   // …etc.
 ];
 ```
 
 ```javascript
-post_id: 33;
+post_id: 1337
 ```
 
 ## Examples

--- a/includes/init.php
+++ b/includes/init.php
@@ -2,88 +2,124 @@
 
 require_once WP_PLUGIN_DIR . '/forms-gutenberg/triggers/email.php';
 
-function create_gf_extra_endpoint()
+// We extend the Email class in order to expose a validate fields method.
+class _Email extends Email
 {
+    public function validateFields($fields = array())
+    {
+        $arranged_fields = [];
+        foreach ($fields as $field_id => $field_value) {
+            $exploded_id = explode("__", $field_id);
+            $field_type = end($exploded_id);
+            $f_DECODED = $this->validator->decode($field_type);
+            $type = array_key_exists('type', $this->validator->decode($field_type)) ? $this->validator->decode($field_type)['type'] : "";
+            $is_valid = $this->validator->validate($type, $field_value, $field_type);
+            $id = end($f_DECODED);
+            $sanitizedValue = $this->validator->sanitizedValue($type, $field_value);
+            $sanitized_field_value = null;
+            if (is_array($field_value)) {
+                $sanitized_field_value = join(",", $field_value);
+            } else if ($id === 'upload') {
+                $sanitized_field_value = $field_value;
+            } else {
+                $sanitized_field_value = $sanitizedValue;
+            }
+            $arranged_data = array(
+                'field_data_id' => $id,
+                'field_value' => $sanitized_field_value,
+                'is_valid' => $field_id === "g-recaptcha-response" ? true : $is_valid,
+                'field_id' => $field_id,
+                'field_type' => $type,
+                'decoded_entry' => $this->validator->decode($field_type),
+            );
+            if ($type === 'file_upload') {
+                $file_to_upload = $_FILES;
+                $file_name = $file_to_upload[$field_id]['name'];
+                $tmp_name = $file_to_upload[$field_id]['tmp_name'];
+                $parsed_alloweds = json_decode($f_DECODED['extra_meta'], false);
+                $ext = pathinfo($file_name, PATHINFO_EXTENSION);
+                $is_allowed = $this->validator->test_file_formats($ext, $parsed_alloweds);
+                if ($is_allowed) {
+                    $created_file = Bucket::upload($tmp_name, $ext);
+                    $arranged_data['file_name'] = $created_file['filename'];
+                    $this->attachments[] = $created_file['path'];
+                } else {
+                    $arranged_data['is_valid'] = false;
+                }
+            }
+            if ($this->validator->is_hidden_data_field($field_id)) {
+                $arranged_data['is_valid'] = true;
+            }
+            $arranged_fields[] = $arranged_data;
+        }
+        return $this->is_fields_valid($arranged_fields) ? $arranged_fields : false;
+    }
+}
+
+add_action('rest_api_init', function () {
     register_rest_route('wp/v2', '/cwp_gf_send_mail', [
         'methods' => 'POST',
-        'callback' => 'send_mail',
+        'callback' => function ($req) {
+            // Get the required params from our request
+            $fields = $req->get_param('fields');
+            $attrs = $req->get_param('attrs');
+            $post_id = $req->get_param('post_id');
+
+            $submit = $attrs['id'];
+            $form_label = $attrs['formLabel'];
+            $form_id = "form-" . explode("-", $submit)[1];
+            $post = get_post($post_id);
+            $parsed_blocks = parse_blocks(do_shortcode($post->post_content));
+
+            // Instantiate the Email class
+            $email = new _Email($parsed_blocks);
+            $valid_fields = $email->validateFields($fields);
+
+            // Check for any errors
+            $error = new WP_Error();
+
+            if (!$fields) {
+                $error->add(400, 'Please provide a fields array. 🙏', 'fields');
+            }
+            if (!$attrs) {
+                $error->add(400, 'Please provide an attrs object. 🙏', 'attrs');
+            }
+            if (!$post_id) {
+                $error->add(400, 'Please provide a post_id. 🙏', 'post_id');
+            }
+            if (!$submit) {
+                $error->add(400, 'Please provide a submit identifier. 🙏', 'submit');
+            }
+            if (!$post) {
+                $error->add(400, "Unable to find a post with the ID of $post_id. 😨", 'post_exists');
+            }
+            if (!$parsed_blocks) {
+                $error->add(400, "Unable to parse any blocks for the post ID $post_id. 😨", 'post_exists');
+            }
+            if (!$valid_fields) {
+                $error->add(400, 'Your fields are not valid. 😨', 'valid_fields');
+            }
+            if (!empty($error->get_error_codes())) {
+                return wp_send_json_error($error);
+            }
+
+            // Add our form label and form ID to the fields array
+            array_push($valid_fields,
+                [
+                    field_value => $form_label,
+                    field_id => 'gf_form_label',
+                ],
+                [
+                    field_value => $form_id,
+                    field_id => 'gf_form_id',
+                ]);
+
+            // Submit our form data and create the entry using the sendMail method.
+            $_POST['submit'] = $submit;
+            $email->sendMail($valid_fields);
+            ob_end_clean();
+
+            return wp_send_json_success('Passed on that data to Gutenberg Forms to process like a boss. 😎');
+        },
     ]);
-}
-
-function validate_request($fields, $attrs, $post_id, $submit, $post, $parsed_blocks)
-{
-    $error = new WP_Error();
-
-    if (!$fields) {
-        $error->add(400, 'Please provide a fields array. 🙏', 'fields');
-    }
-
-    if (!$attrs) {
-        $error->add(400, 'Please provide an attrs object. 🙏', 'attrs');
-    }
-
-    if (!$post_id) {
-        $error->add(400, 'Please provide a post_id. 🙏', 'post_id');
-    }
-
-    if (!$submit) {
-        $error->add(400, 'Please provide a submit identifier. 🙏', 'submit');
-    }
-
-    if (!$post) {
-        $error->add(400, "Unable to find a post with the ID of $post_id. 😨", 'post_exists');
-    }
-
-    if (!$parsed_blocks) {
-        $error->add(400, "Unable to parse any blocks for the post ID $post_id. 😨", 'post_exists');
-    }
-
-    return $error;
-}
-
-function send_mail($req)
-{
-    $fields = $req->get_param('fields');
-    $attrs = $req->get_param('attrs');
-    $submit = $attrs['id'];
-    $post_id = $req->get_param('post_id');
-    $post = get_post($post_id);
-    $parsed_blocks = parse_blocks(do_shortcode($post->post_content));
-    $form_label = $attrs['formLabel'];
-    $form_id = "form-" . explode("-", $submit)[1];
-
-    $error = validate_request($fields, $attrs, $post_id, $submit, $post, $parsed_blocks);
-
-    if (!empty($error->get_error_codes())) {
-        return wp_send_json_error($error);
-    }
-
-    array_push($fields, [
-        field_data_id => false,
-        field_value => $form_label,
-        is_valid => true,
-        field_id => 'gf_form_label',
-        field_type => '',
-        decoded_entry => [],
-    ],
-    [
-        field_data_id => false,
-        field_value => $form_id,
-        is_valid => true,
-        field_id => 'gf_form_id',
-        field_type => '',
-        decoded_entry => [],
-    ]);
-
-    $_POST['submit'] = $submit;
-
-    $email = new Email($parsed_blocks);
-    $email->init();
-    $email->sendMail($fields);
-
-    ob_end_clean();
-    return wp_send_json_success('Passed on that data to Gutenberg Forms to process like a boss. 😎');
-
-}
-
-add_action('rest_api_init', 'create_gf_extra_endpoint');
+});

--- a/plugin.php
+++ b/plugin.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Gutenberg Forms send with REST
  * Plugin URI:        https://github.com/darbymanning/gutenberg-forms-send-with-rest
  * Description:       Creates a new endpoint to send mail via REST with the Gutenberg Forms plugin.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Darby Manning
  * Author URI:        https://darbymanning.com
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if (!defined('WPINC')) {
     die;
 }
 
-define('GUTENBERG_FORMS_TO_REST_VERSION', '1.0.0');
+define('GUTENBERG_FORMS_TO_REST_VERSION', '1.0.1');
 
 if (is_plugin_active('forms-gutenberg/plugin.php')) {
     require_once plugin_dir_path(__FILE__) . 'includes/init.php';


### PR DESCRIPTION
- No longer requires the full field information to be passed (follows a key/value pattern)
- Validates form data using the method provided in Gutenberg Forms. This has been copied for now into our own instance of the Email class. I'll ask the author of GF to make this a public function to keep our code DRY.
- We now favour an anonymous function, so as not to worry about leaky function names etc.